### PR TITLE
Add 'changelog.txt' to the default whitelist.

### DIFF
--- a/SCModManager/StellarisConfiguration.cs
+++ b/SCModManager/StellarisConfiguration.cs
@@ -14,7 +14,7 @@ namespace SCModManager
         public string SettingsPath { get; }
         public string BackupPath { get; }
         public string SavedSelections { get; }
-        public IReadOnlyCollection<string> WhiteListedFiles { get; } = new[] {"description.txt", "modinfo.lua", "descriptor.mod", "readme.txt"};
+        public IReadOnlyCollection<string> WhiteListedFiles { get; } = new[] {"description.txt", "modinfo.lua", "descriptor.mod", "readme.txt", "changelog.txt"};
 
         public StellarisConfiguration()
         {


### PR DESCRIPTION
'Tactical Ship Sections' (https://steamcommunity.com/sharedfiles/filedetails/?id=1345239366) and 'War Name Variety' (https://steamcommunity.com/sharedfiles/filedetails/?id=819007550) both have a `changelog.txt`. There may be more mods out the that have this file, and there is obviously no point is managing conflicts for these.